### PR TITLE
PGF-178 : Update de getAllFootprints et ajout du getAllProjects

### DIFF
--- a/documentation/docs/carbon-api-requests.md
+++ b/documentation/docs/carbon-api-requests.md
@@ -228,18 +228,20 @@ You can find details about how to build the object newTransportationFootprintSim
 
 ## carbon.getAllFootprints()
 
-| Param  | Type                | Description                                                                         |
-| ------ | ------------------- | ----------------------------------------------------------------------------------- |
-| params | <code>IFootprintURLParams</code> | optional, all query params to filter footprints requests based on IFootprintURLParams interface  |
+| Param  | Type                             | Description                                                                                     |
+| ------ | -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| params | <code>IFootprintURLParams</code> | optional, all query params to filter footprints requests based on IFootprintURLParams interface |
 
+-   IFootprintURLParams: object with specifications of all possible params to apply to filter data :
 
--  IFootprintURLParams: object with specifications of all possible params to apply to filter data :
-  ```      
-    params = { 
-        status?: Status | null; // based on enum, choose between 'PURCHASED', 'CLOSED', 'ONGOING' footprints
-        limit?: number | null; // number of entities received inside API response per page, limit is 50 by default
-        page?: number | null; // numerotation of page, number is 1 by default
-    }
+```
+  params = {
+      status?: Status | null; // based on enum, choose between 'PURCHASED', 'CLOSED', 'ONGOING' footprints
+      limit?: number | null; // number of entities received inside API response per page, limit is 50 by default
+      page?: number | null; // numerotation of page, number is 1 by default
+      begin?: string | null; // begin date, accepted format YYYY-MM-DD, all entities received will be posterior to this date
+      end?: string | null; // end date, accepted format YYYY-MM-DD, all entities received will be anterior to this date
+  }
 ```
 
 -   get all carbon footprints, no filter applied.
@@ -421,5 +423,51 @@ You can find details about how to build the object newTransportationFootprintSim
         total_items: 50
     },
     status: 200
+}
+```
+
+## carbon.getAllProjects()
+
+-   get all carbon offsets projects from API linked to user's account.
+
+```
+    return sdk.carbon
+        .getAllProjects()
+        .then((res) => {
+            console.log(res)
+        });
+```
+
+-   API Response
+
+```
+{
+    success: true,
+    dataInfo: {
+        _links: { self: [Object] },
+        _embedded: { project: [Array] },
+        total_items: 1
+    },
+    status: 200
+}
+```
+
+-   Details of one project's object received :
+
+```
+{
+    idProject: '1',
+    name: 'Cordillera Azul National Park',
+    description: 'The Cordillera Azul project targets the deforestation drivers the national park still faces and aligns sustainable economic development with environmental protection by transforming over 3.8 million hectares of threatened forest.',
+    url: 'https://climateseed.com/',
+    createdAt: '0',
+    updatedAt: null,
+    brokerName: 'ClimateSeed',
+    carbonPrice: '706',
+    isActive: '1',
+    country: 'PE',
+    isDefault: '1',
+    picture: null,
+    _links: { self: [Object] }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -7946,6 +7946,15 @@
                 }
             }
         },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
         "react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8256,16 +8265,69 @@
             }
         },
         "rollup-plugin-terser": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-            "integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+            "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "jest-worker": "^24.9.0",
-                "rollup-pluginutils": "^2.8.2",
-                "serialize-javascript": "^2.1.2",
-                "terser": "^4.6.2"
+                "@babel/code-frame": "^7.10.4",
+                "jest-worker": "^26.2.1",
+                "serialize-javascript": "^4.0.0",
+                "terser": "^5.0.0"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/highlight": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-worker": {
+                    "version": "26.6.2",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+                    "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "rollup-plugin-tslint": {
@@ -8355,10 +8417,13 @@
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "serialize-javascript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-            "dev": true
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -8808,14 +8873,14 @@
             }
         },
         "terser": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-            "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+            "version": "5.3.8",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.8.tgz",
+            "integrity": "sha512-zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
+                "source-map": "~0.7.2",
+                "source-map-support": "~0.5.19"
             },
             "dependencies": {
                 "commander": {
@@ -8825,9 +8890,9 @@
                     "dev": true
                 },
                 "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "rollup": "^1.32.0",
         "rollup-plugin-babel": "^4.3.3",
         "rollup-plugin-node-resolve": "^5.2.0",
-        "rollup-plugin-terser": "^5.2.0",
+        "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-tslint": "^0.2.2",
         "ts-jest": "^24.1.0",
         "ts-node": "^8.10.2",

--- a/src/enums/Identifier.ts
+++ b/src/enums/Identifier.ts
@@ -1,7 +1,9 @@
 export enum Identifier {
-    'transportation_mode' = 'name',
     'client_id' = 'client_id',
-    'fingerprint' = 'fingerprint',
+    'footprint' = 'fingerprint',
+    'project' = 'idProject',
+    'purchase' = 'fingerprint',
     'rib' = 'idRib',
+    'transportation_mode' = 'name',
     'user' = 'username',
 }

--- a/src/interfaces/IFootprintURLParams.ts
+++ b/src/interfaces/IFootprintURLParams.ts
@@ -5,9 +5,13 @@ import { Status } from '../enums';
  * @property {Status} status - based on enum, choose between 'PURCHASED', 'CLOSED', 'ONGOING' footprints
  * @property {number} limit - number of entities received inside API response per page, limit is 50 by default
  * @property {number} page - numerotation of page, number is 1 by default
+ * @property {string} begin - begin date, accepted format YYYY-MM-DD, all entities received will be posterior to this date
+ * @property {string} end - end date, accepted format YYYY-MM-DD, all entities received will be anterior to this date
  */
 export interface IFootprintURLParams {
     status?: Status | null;
     limit?: number | null;
     page?: number | null;
+    begin?: string | null;
+    end?: string | null;
 }

--- a/src/resources/Carbon.ts
+++ b/src/resources/Carbon.ts
@@ -14,12 +14,14 @@ import { serialize } from 'typescript-json-serializer';
  * @property {string} webUrl - url to simulate or add web data footprints for this class
  * @property {string} transportationUrl - url to simulate or add transportation data footprints for this class
  * @property {string} purchasesUrl - url to make footprints purchases Api requests for this class
+ * @property {string} projectsUrl - url to make projects Api requests for this class
  */
 export class Carbon extends MainBuilder {
     static footprintUrl = '/carbon/footprints';
     static webUrl = '/carbon/web';
     static transportationUrl = '/carbon/transportation';
     static purchasesUrl = '/carbon/purchases';
+    static projectsUrl = '/carbon/projects';
 
     /**
      * ADD WEB FOOTPRINT | /carbon/web
@@ -267,6 +269,23 @@ export class Carbon extends MainBuilder {
     getAllPurchases = (): Promise<IApiResponse> => {
         return this.axiosRequest
             .get(this.buildUrl(false, Carbon.purchasesUrl))
+            .then((res) => {
+                return this.ApiResponse.formatResponse(
+                    true,
+                    res.data,
+                    res.status,
+                );
+            })
+            .catch(this.ApiResponse.formatError);
+    };
+
+    /**
+     * GET ALL PROJECTS | /carbon/projects/
+     * @returns {Promise.<IApiResponse>} - get all carbon offsets projects from API
+     */
+    getAllProjects = (): Promise<IApiResponse> => {
+        return this.axiosRequest
+            .get(this.buildUrl(false, Carbon.projectsUrl))
             .then((res) => {
                 return this.ApiResponse.formatResponse(
                     true,


### PR DESCRIPTION
## Identifiants SDK :
tout est renseigné dans le ticket PGF-178 sur Jira via un doc mis à jour sur Notion :)
on peut lancer les tests en récupérant à chaque fois les tokens correspondants et en updatant les identifiants.
bien suivre le bon modèle de fichier .env (les tokens à récupérer via Postman sont nécessaires!)

## Bonus :
upgrade du package rollup-plugin-terser qui contient lui même le package `serialize javascript` du à une alerte sécurité sur le repo  (https://github.com/PayGreen/api-green-node/network/alert/package-lock.json/serialize-javascript/open)
je cleanerais la dernière MR du dependabot lors de la prochaine MEP :) 
du coup j'ai laissé l'upgrade dans un commit à part pour te permettre de tester le build sans incidence sur le reste

## Comment tester :
- `npm run test` => tous les tests doivent passer :)