### PR TITLE
PGF-358: création des classes donations et donations reports

### DIFF
--- a/src/Sdk.ts
+++ b/src/Sdk.ts
@@ -3,6 +3,8 @@ import {
     Carbon,
     CarbonReports,
     Charity,
+    Donation,
+    DonationReports,
     Iban,
     Partnership,
     PartnershipGroup,
@@ -18,6 +20,8 @@ export class Sdk {
     public carbon: Carbon;
     public charity: Charity;
     public carbonReports: CarbonReports;
+    public donation: Donation;
+    public donationReports: DonationReports;
     public iban: Iban;
     public partnership: Partnership;
     public partnershipGroup: PartnershipGroup;
@@ -71,6 +75,12 @@ export class Sdk {
             this._host,
         );
         this.charity = new Charity(this._tokens, this._identity, this._host);
+        this.donation = new Donation(this._tokens, this._identity, this._host);
+        this.donationReports = new DonationReports(
+            this._tokens,
+            this._identity,
+            this._host,
+        );
         this.iban = new Iban(this._tokens, this._identity, this._host);
         this.partnership = new Partnership(
             this._tokens,

--- a/src/enums/Identifier.ts
+++ b/src/enums/Identifier.ts
@@ -1,6 +1,7 @@
 export enum Identifier {
     'association' = 'idAssociation',
     'client_id' = 'client_id',
+    'donation' = 'idDonation',
     'fingerprint' = 'fingerprint',
     'footprint' = 'fingerprint',
     'partnership' = 'idPartnership',

--- a/src/interfaces/IDonationReportsURLParams.ts
+++ b/src/interfaces/IDonationReportsURLParams.ts
@@ -1,0 +1,14 @@
+/**
+ * IDonationReportsURLParams
+ * @property {string?} begin - begin date, accepted format YYYY-MM-DD, all entities received will be posterior to this date
+ * @property {string?} end - end date, accepted format YYYY-MM-DD, all entities received will be anterior to this date
+ * @property {string?} association - to check what has been collected for a specific charity/association structure
+ * @property {number?} user - userId - to filter donations reports per user (only for association role)
+ *
+ */
+export interface IDonationReportsURLParams {
+    begin?: string | null;
+    end?: string | null;
+    association?: string | null;
+    user?: string | null;
+}

--- a/src/interfaces/IDonationURLParams.ts
+++ b/src/interfaces/IDonationURLParams.ts
@@ -1,0 +1,20 @@
+/**
+ * IDonationURLParams
+ * @property {string?} begin - begin date, accepted format YYYY-MM-DD, all entities received will be posterior to this date
+ * @property {string?} end - end date, accepted format YYYY-MM-DD, all entities received will be anterior to this date
+ * @property {string?} idAssociation - to check what has been collected for a specific charity/association structure
+ * @property {number?} limit - number of entities received inside API response per page, limit is 25 by default
+ * @property {number?} page - numerotation of page, number is 1 by default
+ * @property { 0 | 1 ?} onlyNotRefundable- numeric literal types are 0|1, if 1, only the Donation that are not refundable anymore (14 days period), will be provided
+ * @property {string?} externalId -  buyer identification provided by shop to display to buyers their donations history
+ *
+ */
+export interface IDonationURLParams {
+    begin?: string | null;
+    end?: string | null;
+    idAssociation?: string | null;
+    limit?: number | null;
+    page?: number | null;
+    onlyNotRefundable?: 0 | 1 | null;
+    externalId?: string | null;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,6 +1,8 @@
 import { IApiResponse } from './IApiResponse';
 import { IApiResponseList } from './IApiResponseList';
 import { IConfig } from './IConfig';
+import { IDonationURLParams } from './IDonationURLParams';
+import { IDonationReportsURLParams } from './IDonationReportsURLParams';
 import { IFootprintURLParams } from './IFootprintURLParams';
 import { IPurchaseURLParams } from './IPurchaseURLParams';
 import { IReportURLParams } from './IReportURLParams';
@@ -13,6 +15,8 @@ export {
     IApiResponse,
     IApiResponseList,
     IConfig,
+    IDonationURLParams,
+    IDonationReportsURLParams,
     IFootprintURLParams,
     IReportURLParams,
     IPurchaseURLParams,

--- a/src/resources/CarbonReports.ts
+++ b/src/resources/CarbonReports.ts
@@ -6,7 +6,7 @@ import { MainBuilder } from '../MainBuilder';
  * @property {string} url - main url to build Api requests for this class
  */
 export class CarbonReports extends MainBuilder {
-    static url: string = '/carbon/statistics/reports?';
+    static url: string = '/carbon/statistics/reports';
 
     /**
      * GET | /carbon/statistics/reports?

--- a/src/resources/Donation.ts
+++ b/src/resources/Donation.ts
@@ -1,0 +1,70 @@
+import {
+    IApiResponse,
+    IApiResponseList,
+    IDonationURLParams,
+} from '../interfaces';
+import { MainBuilder } from '../MainBuilder';
+
+/**
+ * Donation Class with all methods to request/modify Donation infos
+ * @property {string} urlDonation -  url to build Api requests for Donation info in this class
+ */
+export class Donation extends MainBuilder {
+    static urlDonation: string = '/donation';
+
+    /**
+     * GET ALL | /donation
+     * @param {IDonationURLParams?} params - all query params to filter donations requests based on IDonationURLParams interface
+     * @returns {Promise.<IApiResponseList>} - get donations of last past month (eq 30/31 days) by default
+     */
+    getAll = (params?: IDonationURLParams): Promise<IApiResponseList> => {
+        return this.axiosRequest
+        .get(Donation.urlDonation + '?', {
+            params: params,
+        })
+            .then((res) => {
+                return this.ApiResponse.formatResponse(
+                    true,
+                    res.data,
+                    res.status,
+                );
+            })
+            .catch(this.ApiResponse.formatError);
+    };
+
+    /**
+     * GET ONE | /donation/{idDonation}
+     *  @param {string} idDonation -
+     *  @returns {Promise.<IApiResponse>} Get information about a donation based on id
+     */
+    getOne = (idAssociation: string): Promise<IApiResponse> => {
+        return this.axiosRequest
+            .get(this.buildUrl(true, Donation.urlDonation, idAssociation))
+            .then((res) => {
+                return this.ApiResponse.formatResponse(
+                    true,
+                    res.data,
+                    res.status,
+                );
+            })
+            .catch(this.ApiResponse.formatError);
+    };
+
+    /**
+     * REFUND ONE | /donation/{idDonation}
+     *  @param {string} idDonation - to cancel and refund one donation based on its id
+     *  @returns {Promise.<IApiResponse>} - get response with status 204 if success.
+     */
+    refund = (idDonation: string): Promise<IApiResponse> => {
+        return this.axiosRequest
+            .delete(this.buildUrl(true, Donation.urlDonation, idDonation))
+            .then((res) => {
+                return this.ApiResponse.formatResponse(
+                    true,
+                    'donation refunded successfully',
+                    res.status,
+                );
+            })
+            .catch(this.ApiResponse.formatError);
+    };
+}

--- a/src/resources/DonationReports.ts
+++ b/src/resources/DonationReports.ts
@@ -6,7 +6,7 @@ import { MainBuilder } from '../MainBuilder';
  * @property {string} urlDonationReports - main url to build Api requests for this class
  */
 export class DonationReports extends MainBuilder {
-    static urlDonationReports: string = '/donation/statistics/reports?';
+    static urlDonationReports: string = '/donation/statistics/reports';
 
     /**
      * GET | /donation/statistics/reports?

--- a/src/resources/DonationReports.ts
+++ b/src/resources/DonationReports.ts
@@ -1,0 +1,30 @@
+import { IApiResponse, IDonationReportsURLParams } from '../interfaces';
+import { MainBuilder } from '../MainBuilder';
+
+/**
+ * Donation Reports Class with all methods to request donation reports infos
+ * @property {string} urlDonationReports - main url to build Api requests for this class
+ */
+export class DonationReports extends MainBuilder {
+    static urlDonationReports: string = '/donation/statistics/reports?';
+
+    /**
+     * GET | /donation/statistics/reports?
+     * @param {IDonationReportsURLParams?} params - all query params to filter report requests based on IDonationReportsURLParams interface
+     * @returns {Promise.<IApiResponse>} - get datas of last past month (eq 30/31 days) by default or on a specific period and with daily details if specified
+     */
+    get = (params?: IDonationReportsURLParams): Promise<IApiResponse> => {
+        return this.axiosRequest
+            .get(DonationReports.urlDonationReports + '?', {
+                params: params,
+            })
+            .then((res) => {
+                return this.ApiResponse.formatResponse(
+                    true,
+                    res.data,
+                    res.status,
+                );
+            })
+            .catch(this.ApiResponse.formatError);
+    };
+}

--- a/src/resources/Partnership.ts
+++ b/src/resources/Partnership.ts
@@ -78,7 +78,7 @@ export class Partnership extends MainBuilder {
         status: PartnershipStatus,
     ): Promise<IApiResponse> => {
         const updatedPartnership = { accountStatus: PartnershipStatus[status] };
-
+        
         return this.axiosRequest
             .put(
                 this.buildUrl(true, Partnership.urlPartnership, idPartnership),

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -2,10 +2,24 @@ import { Authentication } from './Authentication';
 import { Carbon } from './Carbon';
 import { CarbonReports } from './CarbonReports';
 import { Charity } from './Charity';
+import { Donation } from './Donation';
+import { DonationReports } from './DonationReports';
 import { Iban } from './Iban';
 import { Partnership } from './Partnership';
 import { PartnershipGroup } from './PartnershipGroup';
 import { Transport } from './Transport';
 import { User } from './User';
 
-export { Authentication, Carbon, CarbonReports, Charity, Iban, Partnership, PartnershipGroup, Transport, User };
+export {
+    Authentication,
+    Carbon,
+    CarbonReports,
+    Charity,
+    Donation,
+    DonationReports,
+    Iban,
+    Partnership,
+    PartnershipGroup,
+    Transport,
+    User,
+};

--- a/test/Donation.test.ts
+++ b/test/Donation.test.ts
@@ -1,0 +1,84 @@
+require('dotenv').config('/.env');
+import { Sdk } from '../src';
+import { ApiResponse } from '../src/models/ApiResponse';
+import { UserType } from '../src/enums';
+import { IDonationURLParams } from '../src/interfaces';
+import { autoLocaleConfig } from './config/autoConfig';
+
+test('it gets all donations and then gets all ids directly, with shop user type (role=ADMIN or PAYGREEN)', async () => {
+    const sdk = new Sdk(await autoLocaleConfig(UserType.SHOP));
+
+    return sdk.donation.getAll().then((data: any) => {
+        expect(data).toBeDefined();
+        expect(data.dataInfo).toHaveProperty('total_items');
+
+        for (let key in ApiResponse.getIdList(data)) {
+            expect(ApiResponse.getIdList(data)[key]).toHaveProperty(
+                'idDonation',
+            );
+        }
+    });
+});
+
+let today = new Date();
+today.setUTCHours(0, 0, 0, 0); // we reset the current day to midnight
+
+const currentDayParams = {
+    begin: today.toISOString().slice(0, 10),
+    end: new Date(today.setDate(today.getDate() + 1))
+        .toISOString()
+        .slice(0, 10),
+};
+
+const timestampBegin = new Date(currentDayParams.begin).getTime() / 1000; // we convert timestamp from milliseconds to seconds to fit timestamps format from API
+const timestampEnd = new Date(currentDayParams.end).getTime() / 1000;
+
+test('it gets all donations limited with begin and end dates covering the current day', async () => {
+    const sdk = new Sdk(await autoLocaleConfig(UserType.SHOP));
+
+    return sdk.donation.getAll(currentDayParams).then((data: any) => {
+        expect(ApiResponse.isSuccessful(data)).toBe(true);
+
+        if (data.dataInfo._embedded.donation.length) {
+            data.dataInfo._embedded.donation.forEach((e) => {
+                expect(e.createdAt).toBeGreaterThanOrEqual(timestampBegin);
+                expect(e.createdAt).toBeLessThan(timestampEnd);
+            });
+        }
+    });
+});
+
+test('it gets all donations limited to 20 results maximum', async () => {
+    const sdk = new Sdk(await autoLocaleConfig(UserType.SHOP));
+    const params: IDonationURLParams = {
+        limit: 20,
+    };
+
+    return sdk.donation.getAll(params).then((data: any) => {
+        expect(ApiResponse.isSuccessful(data)).toBe(true);
+        expect(data.dataInfo._embedded.donation.length).toBeLessThanOrEqual(20);
+    });
+});
+
+test('if at least one donation has been made, it gets the last one created based on its id and then gets its id directly', async () => {
+    const sdk = new Sdk(await autoLocaleConfig(UserType.SHOP));
+
+    return sdk.donation.getAll().then((data: any) => {
+        expect(data).toBeDefined();
+
+        if (data.dataInfo._embedded.donation.length) {
+            // we get by default the id of the first donation from the list
+            const idDonation = Object.values(ApiResponse.getIdList(data)[0])[0];
+
+            return sdk.donation.getOne(idDonation).then((data: any) => {
+                expect(ApiResponse.getId(data)).toHaveProperty(
+                    'idDonation',
+                    idDonation,
+                );
+            });
+        }
+    });
+});
+
+// stand by tests for refund donation will be made after fix inside API
+test('it creates a donation, then refunds it', async () => {});

--- a/test/DonationReports.test.ts
+++ b/test/DonationReports.test.ts
@@ -1,0 +1,53 @@
+require('dotenv').config('/.env');
+import { Sdk } from '../src';
+import { ApiResponse, Tools } from '../src/models';
+import { UserType } from '../src/enums';
+import { IDonationReportsURLParams } from '../src/interfaces';
+import { autoLocaleConfig } from './config/autoConfig';
+
+test('it gets donation reports without any parameter and check if there is a details object if any donation has been made', async () => {
+    const sdk = new Sdk(await autoLocaleConfig(UserType.SHOP));
+
+    return sdk.donationReports.get().then((data: any) => {
+        expect(ApiResponse.isSuccessful(data)).toBe(true);
+        expect(data.dataInfo).toHaveProperty('donationCount');
+        expect(data.dataInfo).toHaveProperty('totalDonationAmount');
+        expect(data.dataInfo).toHaveProperty('maximumDonationAmount');
+        expect(data.dataInfo).toHaveProperty('minimumDonationAmount');
+        expect(data.dataInfo).toHaveProperty('averageDonationAmount');
+
+        if (data.dataInfo.donationCount) {
+            expect(data.dataInfo).toHaveProperty('details');
+        }
+    });
+});
+
+test('it gets donation reports with begin and end dates as parameters', async () => {
+    const sdk = new Sdk(await autoLocaleConfig(UserType.SHOP));
+
+    const today = new Date().toISOString().substring(0, 10);
+    const params: IDonationReportsURLParams = {
+        end: today,
+        begin: '2020-03-29',
+    };
+
+    return sdk.donationReports.get(params).then((data: any) => {
+        expect(ApiResponse.isSuccessful(data)).toBe(true);
+        expect(data.dataInfo).toHaveProperty('donationCount');
+        expect(data.dataInfo).toHaveProperty('end', today);
+        expect(data.dataInfo).toHaveProperty('begin', '2020-03-29');
+    });
+});
+
+test('it gets donation reports without any parameter, converts estimated donations in euros cents to euros', async () => {
+    const sdk = new Sdk(await autoLocaleConfig(UserType.SHOP));
+
+    return sdk.donationReports.get().then((data: any) => {
+        expect(ApiResponse.isSuccessful(data)).toBe(true);
+        expect(data.dataInfo).toHaveProperty('totalDonationAmount');
+        const PriceInEuros = Tools.eurosCentstoEuros(
+            data.dataInfo.totalDonationAmount,
+        );
+        expect(PriceInEuros).toEqual(data.dataInfo.totalDonationAmount / 100);
+    });
+});


### PR DESCRIPTION
## How to test ? :  
- `npm run test` => tous les tests passent

## Bien suivre le modèle de .env sur Notion (celui avec les identifiants pour shop et charity, sans les tokens)

## warning interfaces IDonationReportsURLParams / IDonationURLParams
- la clé association s'appelle soit "association" soit "idAssociation" c'est dû à une incohérence dans l'API (vu avec Benjamin)